### PR TITLE
change oracle linux tags

### DIFF
--- a/v1.10/oraclelinux/Dockerfile
+++ b/v1.10/oraclelinux/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) 2020, Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl.
 
-FROM container-registry.oracle.com/os/oraclelinux:7-slim 
+FROM container-registry.oracle.com/os/oraclelinux:7-slim@sha256:9b86d1332a883ee8f68dd44ba42133de518b2e0ec1cc70257e59fb4da86b1ad3
 LABEL maintainer ="Verrazzano developers <verrazzano_ww@oracle.com>"
 LABEL Description="Fluentd docker image for Oracle Linux 7" Vendor="Oracle" Version="1.10.4"
 ENV TINI_VERSION=0.18.0


### PR DESCRIPTION
use SHA256 tags for Oracle Linux images

https://build.verrazzano.io/job/verrazzano/job/pmackin-images-4-fluent-etc/2/